### PR TITLE
Add joomlacode and move forum to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ downloads | [downloads.joomla.org](https://downloads.joomla.org) | [report jdown
 events | [community.joomla.org/events.html](https://community.joomla.org/events.html) | [report jevnt](https://github.com/joomla/joomla-websites/issues/new?title=[jevnt]%20)
 exam | [exam.joomla.org](https://exam.joomla.org) | [report jexam](https://github.com/joomla/joomla-websites/issues/new?title=[jexam]%20)
 extensions | [extensions.joomla.org](https://extensions.joomla.org) | [report jed](https://joomlaextensionsdirectory.atlassian.net/secure/Dashboard.jspa)
-forum | [forum.joomla.org](http://forum.joomla.org) | [report jforum](https://github.com/joomla/joomla-websites/issues/new?title=[jforum]%20)
+forum | [forum.joomla.org](https://forum.joomla.org) | [report jforum](https://github.com/joomla/joomla-websites/issues/new?title=[jforum]%20)
 framework | [framework.joomla.org](https://framework.joomla.org) | [report FW](https://github.com/joomla/framework.joomla.org/issues/new?title=[FW%20Site]&body=Please%20state%20the%20nature%20of%20your%20development%20emergency)
 help | [help.joomla.org](https://help.joomla.org) | [report jhelp](https://github.com/joomla/joomla-websites/issues/new?title=[jhelp]%20)
 ideas | [ideas.joomla.org](http://ideas.joomla.org) | [report jideas](https://github.com/joomla/joomla-websites/issues/new?title=[jideas]%20)
@@ -43,3 +43,4 @@ update | [update.joomla.org](https://update.joomla.org) | [report update](https:
 vel | [vel.joomla.org](https://vel.joomla.org) | [report jvel](https://github.com/joomla/joomla-websites/issues/new?title=[jvel]%20)
 volunteers | [volunteers.joomla.org](https://volunteers.joomla.org) | [report jvols](https://github.com/joomla/joomla-websites/issues/new?title=[jvols]%20)
 joomla! 3 | [joomla.org/3](https://www.joomla.org/3) | [report j3](https://github.com/joomla/joomla-websites/issues/new?title=[j3]%20)
+joomlacode | [joomlacode.org](http://joomlacode.org) | [report jcode](https://github.com/joomla/joomla-websites/issues/new?title=[jcode]%20)


### PR DESCRIPTION
Add back joomlacode (even if we just us it for the language packs but it is still a public site by the project) and move forum to https