### PR TITLE
Add link to website repository if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,36 +11,36 @@ To help the webmasters, please:
 
 ### Websites
 
-Website | URL | Reporting Links
-------- | ------ | ------
-joomla.org | [joomla.org](https://www.joomla.org) | [report j.org](https://github.com/joomla/joomla-websites/issues/new?title=[jorg]%20)
-test-joomla.org | [repository.joomla.org](http://repository.joomla.org) | [report jrepo](https://github.com/joomla/joomla-websites/issues/new?title=[jrepo]%20)
-api | [api.joomla.org](https://api.joomla.org) | [report japi](https://github.com/joomla/joomla-websites/issues/new?title=[japi]%20)
-certification | [certification.joomla.org](https://certification.joomla.org) | [report jcertif](https://github.com/joomla/joomla-websites/issues/new?title=[jcertif]%20)
-coding-standards | [developer.joomla.org/coding-standards.html](https://developer.joomla.org/coding-standards.html) | [report jstand](https://github.com/joomla/joomla-websites/issues/new?title=[jstand]%20)
-community | [community.joomla.org](https://community.joomla.org) | [report jcomm](https://github.com/joomla/joomla-websites/issues/new?title=[jcomm]%20)
-conference | [conference.joomla.org](https://conference.joomla.org) | [report jconf](https://github.com/joomla/joomla-websites/issues/new?title=[jconf]%20)
-developer | [developer.joomla.org](https://developer.joomla.org) | [report jdev](https://github.com/joomla/joomla-websites/issues/new?title=[jdev]%20)
-docs | [docs.joomla.org](https://docs.joomla.org) | [report jdocs](https://github.com/joomla/joomla-websites/issues/new?title=[jdocs]%20)
-downloads | [downloads.joomla.org](https://downloads.joomla.org) | [report jdown](https://github.com/joomla/joomla-websites/issues/new?title=[jdown]%20)
-events | [community.joomla.org/events.html](https://community.joomla.org/events.html) | [report jevnt](https://github.com/joomla/joomla-websites/issues/new?title=[jevnt]%20)
-exam | [exam.joomla.org](https://exam.joomla.org) | [report jexam](https://github.com/joomla/joomla-websites/issues/new?title=[jexam]%20)
-extensions | [extensions.joomla.org](https://extensions.joomla.org) | [report jed](https://github.com/joomla/jed-issues/issues/new)
-forum | [forum.joomla.org](https://forum.joomla.org) | [report jforum](https://github.com/joomla/joomla-websites/issues/new?title=[jforum]%20)
-framework | [framework.joomla.org](https://framework.joomla.org) | [report FW](https://github.com/joomla/framework.joomla.org/issues/new?title=[FW%20Site]&body=Please%20state%20the%20nature%20of%20your%20development%20emergency)
-help | [help.joomla.org](https://help.joomla.org) | [report jhelp](https://github.com/joomla/joomla-websites/issues/new?title=[jhelp]%20)
-ideas | [ideas.joomla.org](http://ideas.joomla.org) | [report jideas](https://github.com/joomla/joomla-websites/issues/new?title=[jideas]%20)
-issues | [issues.joomla.org](https://issues.joomla.org) | [report jissues](http://issues.joomla.org/tracker/jtracker)
-magazine | [magazine.joomla.org](https://magazine.joomla.org) | [report jcm](https://github.com/joomla/joomla-websites/issues/new?title=[jcm]%20)
-osm | [opensourcematters.org](http://opensourcematters.org) | [report josm](https://github.com/joomla/joomla-websites/issues/new?title=[josm]%20)
-resources | [resources.joomla.org](http://resources.joomla.org) | [report jrd](https://github.com/joomla/joomla-websites/issues/new?title=[jrd]%20)
-shop | [community.joomla.org/the-joomla-shop.html](https://community.joomla.org/the-joomla-shop.html) | [report jshop](https://github.com/joomla/joomla-websites/issues/new?title=[jshop]%20)
-showcase | [showcase.joomla.org](https://showcase.joomla.org) | [report jshow](https://github.com/joomla/joomla-websites/issues/new?title=[jshow]%20)
-sponsor | [joomla.org/sponsor.html](https://www.joomla.org/sponsor.html) | [report jspons](https://github.com/joomla/joomla-websites/issues/new?title=[jspons]%20)
-trademark | [tm.joomla.org](https://tm.joomla.org) | [report jtm](https://github.com/joomla/joomla-websites/issues/new?title=[jtm]%20)
-training | [community.joomla.org/joomla-training.html](https://community.joomla.org/joomla-training.html) | [report jtrain](https://github.com/joomla/joomla-websites/issues/new?title=[jtrain]%20)
-update | [update.joomla.org](https://update.joomla.org) | [report update](https://github.com/joomla/update.joomla.org/issues/new?title=[update]%20)
-vel | [vel.joomla.org](https://vel.joomla.org) | [report jvel](https://github.com/joomla/joomla-websites/issues/new?title=[jvel]%20)
-volunteers | [volunteers.joomla.org](https://volunteers.joomla.org) | [report jvols](https://github.com/joomla/volunteers.joomla.org/issues/new?title=[jvols]%20)
-joomla! 3 | [joomla.org/3](https://www.joomla.org/3) | [report j3](https://github.com/joomla/joomla-websites/issues/new?title=[j3]%20)
-joomlacode | [joomlacode.org](http://joomlacode.org) | [report jcode](https://github.com/joomla/joomla-websites/issues/new?title=[jcode]%20)
+Website | URL | Reporting Links | Repository
+------- | ------ | ------ | ------
+joomla.org | [joomla.org](https://www.joomla.org) | [report j.org](https://github.com/joomla/joomla-websites/issues/new?title=[jorg]%20) | https://github.com/joomla/joomla.org
+test-joomla.org | [repository.joomla.org](http://repository.joomla.org) | [report jrepo](https://github.com/joomla/joomla-websites/issues/new?title=[jrepo]%20) | N/A
+api | [api.joomla.org](https://api.joomla.org) | [report japi](https://github.com/joomla/joomla-websites/issues/new?title=[japi]%20) | https://github.com/joomla/api.joomla.org
+certification | [certification.joomla.org](https://certification.joomla.org) | [report jcertif](https://github.com/joomla/joomla-websites/issues/new?title=[jcertif]%20) | N/A
+coding-standards | [developer.joomla.org/coding-standards.html](https://developer.joomla.org/coding-standards.html) | [report jstand](https://github.com/joomla/joomla-websites/issues/new?title=[jstand]%20) | https://github.com/joomla/coding-standards
+community | [community.joomla.org](https://community.joomla.org) | [report jcomm](https://github.com/joomla/joomla-websites/issues/new?title=[jcomm]%20) | N/A
+conference | [conference.joomla.org](https://conference.joomla.org) | [report jconf](https://github.com/joomla/joomla-websites/issues/new?title=[jconf]%20) | N/A
+developer | [developer.joomla.org](https://developer.joomla.org) | [report jdev](https://github.com/joomla/joomla-websites/issues/new?title=[jdev]%20) | https://github.com/joomla/developer.joomla.org
+docs | [docs.joomla.org](https://docs.joomla.org) | [report jdocs](https://github.com/joomla/joomla-websites/issues/new?title=[jdocs]%20) | N/A
+downloads | [downloads.joomla.org](https://downloads.joomla.org) | [report jdown](https://github.com/joomla/joomla-websites/issues/new?title=[jdown]%20) | N/A
+events | [community.joomla.org/events.html](https://community.joomla.org/events.html) | [report jevnt](https://github.com/joomla/joomla-websites/issues/new?title=[jevnt]%20) | N/A
+exam | [exam.joomla.org](https://exam.joomla.org) | [report jexam](https://github.com/joomla/joomla-websites/issues/new?title=[jexam]%20) | N/A
+extensions | [extensions.joomla.org](https://extensions.joomla.org) | [report jed](https://github.com/joomla/jed-issues/issues/new) | N/A
+forum | [forum.joomla.org](https://forum.joomla.org) | [report jforum](https://github.com/joomla/joomla-websites/issues/new?title=[jforum]%20) | N/A
+framework | [framework.joomla.org](https://framework.joomla.org) | [report FW](https://github.com/joomla/framework.joomla.org/issues/new?title=[FW%20Site]&body=Please%20state%20the%20nature%20of%20your%20development%20emergency) | https://github.com/joomla/framework.joomla.org
+help | [help.joomla.org](https://help.joomla.org) | [report jhelp](https://github.com/joomla/joomla-websites/issues/new?title=[jhelp]%20) | https://github.com/joomla/help.joomla.org
+ideas | [ideas.joomla.org](http://ideas.joomla.org) | [report jideas](https://github.com/joomla/joomla-websites/issues/new?title=[jideas]%20) | N/A
+issues | [issues.joomla.org](https://issues.joomla.org) | [report jissues](http://issues.joomla.org/tracker/jtracker) | https://github.com/joomla/jissues
+magazine | [magazine.joomla.org](https://magazine.joomla.org) | [report jcm](https://github.com/joomla/joomla-websites/issues/new?title=[jcm]%20) | N/A
+osm | [opensourcematters.org](http://opensourcematters.org) | [report josm](https://github.com/joomla/joomla-websites/issues/new?title=[josm]%20) | N/A
+resources | [resources.joomla.org](http://resources.joomla.org) | [report jrd](https://github.com/joomla/joomla-websites/issues/new?title=[jrd]%20) | N/A
+shop | [community.joomla.org/the-joomla-shop.html](https://community.joomla.org/the-joomla-shop.html) | [report jshop](https://github.com/joomla/joomla-websites/issues/new?title=[jshop]%20) | N/A
+showcase | [showcase.joomla.org](https://showcase.joomla.org) | [report jshow](https://github.com/joomla/joomla-websites/issues/new?title=[jshow]%20) | N/A
+sponsor | [joomla.org/sponsor.html](https://www.joomla.org/sponsor.html) | [report jspons](https://github.com/joomla/joomla-websites/issues/new?title=[jspons]%20) | N/A
+trademark | [tm.joomla.org](https://tm.joomla.org) | [report jtm](https://github.com/joomla/joomla-websites/issues/new?title=[jtm]%20) | N/A
+training | [community.joomla.org/joomla-training.html](https://community.joomla.org/joomla-training.html) | [report jtrain](https://github.com/joomla/joomla-websites/issues/new?title=[jtrain]%20) | N/A
+update | [update.joomla.org](https://update.joomla.org) | [report update](https://github.com/joomla/update.joomla.org/issues/new?title=[update]%20) | https://github.com/joomla/update.joomla.org
+vel | [vel.joomla.org](https://vel.joomla.org) | [report jvel](https://github.com/joomla/joomla-websites/issues/new?title=[jvel]%20) | N/A
+volunteers | [volunteers.joomla.org](https://volunteers.joomla.org) | [report jvols](https://github.com/joomla/volunteers.joomla.org/issues/new?title=[jvols]%20) | https://github.com/joomla/volunteers.joomla.org
+joomla! 3 | [joomla.org/3](https://www.joomla.org/3) | [report j3](https://github.com/joomla/joomla-websites/issues/new?title=[j3]%20) | N/A
+joomlacode | [joomlacode.org](http://joomlacode.org) | [report jcode](https://github.com/joomla/joomla-websites/issues/new?title=[jcode]%20) | N/A


### PR DESCRIPTION
A fair number of the websites have public repositories containing their resources.  Let's link to those as well, this may encourage interested parties to submit pull requests to fix issues or contribute improvements over just filing an issue report.